### PR TITLE
Add pre login event to permit plugins to allow/deny logins.

### DIFF
--- a/src/proxy.py
+++ b/src/proxy.py
@@ -354,7 +354,11 @@ class Client: # handle client/game connection
 					self.packet.setCompression(256)
 					
 				# Ban code should go here
-				
+
+				if not self.wrapper.callEvent("player.preLogin", {"player": self.username, "online_uuid": self.uuid, "offline_uuid": self.serverUUID, "ip": self.addr[0]}):
+					self.disconnect("Login denied.")
+					return False
+
 				self.send(0x02, "string|string", (str(self.uuid), self.username))
 				self.state = 3
 				self.connect()


### PR DESCRIPTION
This passes name, online/offline uuid and IP address to a plugin via the "player.preLogin" event. If the event returns True the user login proceeds, False it fails.

This isn't ideal as I'd like to pass back a message, but it'd require a larger rework of the event system then I feel capable of. Additionally I can't get the "Login denied." message to make it to the client, I think the Client side is already expecting encryption and the wrapper isn't quite in the state to send it. In lieu of a complete ban/whitelist system this allows plugins to handle it.

My use case of it is simply:
        def onPlayerPreLogin(self, data):
                return self.redis.sismember("knownUsers", data["online_uuid"]) == 1
