### PR TITLE
Bugfix: send_position() variable typo

### DIFF
--- a/src/proxy.py
+++ b/src/proxy.py
@@ -965,7 +965,7 @@ class Packet: # PACKET PARSING CODE
 	def send_uuid(self, payload):
 		return payload.bytes
 	def send_position(self, payload):
-		x, y, z = position
+		x, y, z = payload
 		return self.send_long(((x & 0x3FFFFFF) << 38) | ((y & 0xFFF) << 26) | (z & 0x3FFFFFF))
 	def send_metadata(self, payload):
 		b = ""


### PR DESCRIPTION
Small typo to fix. This function is not used in codebase right now but could be used in plugins (to interact directly with server or client).