### PR TITLE
Corrected pip command to be uninstall, not remove

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 #Overview#
 Wrapper.py is an easy to use Minecraft server wrapper for adding extra functionality into the server without modifying the server jar file.
 
-</br></br>It also comes with a relatively simple and straight-forward - yet powerful - plugin API that can be used to create Bukkit-like plugins on vanilla. 
+</br></br>It also comes with a relatively simple and straight-forward - yet powerful - plugin API that can be used to create Bukkit-like plugins on vanilla.
 
 #Installation#
 Wrapper.py doesn't require any special modules for most of the basic features to work, but web mode and proxy mode require `requests` and `pycrypto`, and `pkg_resources`.
 
 You will also need `tar` installed if you need backups. Most Linux distros have this pre-installed, but you may need to install it manually on Windows: http://gnuwin32.sourceforge.net/packages/gtar.htm
 
-You only need to download Wrapper.py, the src folder is just the extracted version of Wrapper.py.</br>  
+You only need to download Wrapper.py, the src folder is just the extracted version of Wrapper.py.</br>
 
 
 **LINUX Installation**
@@ -21,7 +21,7 @@ or the following to download the unstable, development version of Wrapper.py:
 ```wget https://raw.githubusercontent.com/benbaptist/minecraft-wrapper/development/Wrapper.py```
 
 To install dependencies, use pip:
-  
+
 ```pip install requests pkg_resources pycrypto```
 
 Place the wrapper.py file in your minecraft folder and then run `python Wrapper.py` to start.
@@ -36,7 +36,7 @@ for best results, ensure the add python.exe to path is installed during the setu
 
 Python 2.7 should already have pip and setuptools installed, however they will be old versions.  You should manually remove them and install the updated versions from the command prompt (need to be administrator to do this):
 ```
-pip remove setuptools
+pip uninstall setuptools
 pip install pip
 pip install setuptools
 ```
@@ -62,13 +62,13 @@ Download the wrapper.py file and place it in your minecraft folder, then create 
 **Start Up**
 
 
-Run `python Wrapper.py` to start. On first start, it'll create a wrapper.properties file for you to configure and exit. Set it to boot the jar file of your choice, and then start Wrapper.py again. 
+Run `python Wrapper.py` to start. On first start, it'll create a wrapper.properties file for you to configure and exit. Set it to boot the jar file of your choice, and then start Wrapper.py again.
 
 Wrapper.py is a Python-executable zipped-up folder, rather than a plain text file. If you want to view the source code, open it
-with a zip file viewer OR download the src folder.</br>   
-On first run, it'll create the configuration file 'wrapper.properties' and exit. Tune this file to your needs, and then run `python Wrapper.py` again.</br>  
-Any console command beginning with a slash (/) will be interpreted as a Wrapper.py command. 
-Type /help to see a list of Wrapper.py commands. To completely shutdown the wrapper, type /halt.</br>  
+with a zip file viewer OR download the src folder.</br>
+On first run, it'll create the configuration file 'wrapper.properties' and exit. Tune this file to your needs, and then run `python Wrapper.py` again.</br>
+Any console command beginning with a slash (/) will be interpreted as a Wrapper.py command.
+Type /help to see a list of Wrapper.py commands. To completely shutdown the wrapper, type /halt.</br>
 If you run into any bugs, please report them!
 
 Wrapper.py is made to work with 1.7.10 and later, but it will work on 1.7.4 and earlier if you don't use proxy mode. If you're using 1.6 and earlier, please turn on pre-1.7-mode in wrapper.properties.
@@ -77,7 +77,7 @@ Wrapper.py is made to work with 1.7.10 and later, but it will work on 1.7.4 and 
 Wrapper.py supports the following features:
 - Plugin system for adding Bukkit-like features to a vanilla server
   - Proxy mode allows you to add extra functionality to plugins, such as real /commands
-  - Permissions system with group support 
+  - Permissions system with group support
   - Jump to different servers without reconnecting (extremely experimental, can be used by calling api.minecraft.connect(ip, port) )
 - Automatic Backups
   - Automatically delete the oldest backups once you reach amount of backups
@@ -95,13 +95,13 @@ Wrapper.py supports the following features:
 The doucmentation for Wrapper.py is not complete, but you can find a quick reference on the plugin API here:
 </br><a href="http://wrapper.benbaptist.com/docs/api.html">http://wrapper.benbaptist.com/docs/api.html</a>
 
-It isn't finished, nor is it pretty, but it should help give you an idea of the methods that can be used. More documentation will be released 
+It isn't finished, nor is it pretty, but it should help give you an idea of the methods that can be used. More documentation will be released
 for working with the plugin API, but for now, here's a few things.</br></br>
 
 <b>List of events</b>: https://docs.google.com/spreadsheet/ccc?key=0AoWx24EFSt80dDRiSGVxcW1xQkVLb2dWTUN4WE5aNmc&usp=sharing</br>
 
 </br></br>Check the 'example-plugins' folder to see some example plugins.
-<ul> 
+<ul>
 <li>template.py does nothing - it is just the shell of a plugin to work off of.</li>
 <li>example.py contains some actual functions. </li>
 <li>zombie.py is a fun test plugin that leaves behind undead versions of people when killed by undead mobs.</li>


### PR DESCRIPTION
Minor modification to README.md file. There is no "pip remove" command, and I think this should be "pip uninstall". Also, some trailing whitespace was removed from the text file.