### PR TITLE
Re-enable vanilla command output in console

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -335,7 +335,7 @@ class Server:
 			line = " ".join(buff.split(" ")[2:])
 		else:
 			line = " ".join(buff.split(" ")[3:])
-		#print buff
+		print buff
 		deathPrefixes = ["fell", "was", "drowned", "blew", "walked", "went", "burned", "hit", "tried", 
 			"died", "got", "starved", "suffocated", "withered"]
 		if not self.config["General"]["pre-1.7-mode"]:


### PR DESCRIPTION
PR #248 disabled vanilla command output in the server console forcing users to tail the server log to view output, i.e. the list command. This PR re-enables it