### PR TITLE
Lvl 4 OPs bypass api.registerCommand() permissions

### DIFF
--- a/wrapper/core/commands.py
+++ b/wrapper/core/commands.py
@@ -114,7 +114,7 @@ class Commands:
             if commandname in self.commands[pluginID]:
                 try:
                     command = self.commands[pluginID][commandname]
-                    if player.hasPermission(command["permission"]):
+                    if player.hasPermission(command["permission"]) or player.isOp() >= 4:
                         command["callback"](payload["player"], payload["args"])
                     else:
                         player.message({"translate": "commands.generic.permission", "color": "red"})


### PR DESCRIPTION
Expanded if statement on line 117 to allow sever OPs with level 4 or higher to execute commands defined by api.registerCommand() regardless of permissions.

OPs of this level have the ability to give themselves any permissions anyway, why not save them the time of giving themselves all the extra permissions?