### PR TITLE
Dress up DiscordRelay plugin

### DIFF
--- a/build/CHANGELOG.DEV.md
+++ b/build/CHANGELOG.DEV.md
@@ -1,4 +1,4 @@
-Build 10 [1.0.8 RC 10]
+Build 11 [1.0.8 RC 11]
 - Remove player.interact event out of the block placement code because there
  really is no way to tell if the client is interacting or not based on inventory.
  clicking on a chest with no item or clicking on a chest with a block in hand still
@@ -9,6 +9,7 @@ Build 10 [1.0.8 RC 10]
  also corrects the documentation that did not list player as a payload.  Retained
  the "playername" payload in these events, for backwards compatibility.
 - Optimize regions plugin some more.
+- adds DiscordRelay plugin by @PurePi
 
 Build 9 [1.0.7 RC 9]
 - Fix wrapper client inventory bugs (inconsistent use of None versus {"id" = -1}

--- a/stable-plugins/DiscordRelay.py
+++ b/stable-plugins/DiscordRelay.py
@@ -1,3 +1,13 @@
+# coding=utf-8
+
+from sys import version_info
+try:
+    # noinspection PyPackageRequirements
+    import discord
+except ImportError:
+    discord = False
+PY3 = version_info > (3, 5)
+
 AUTHOR = "PurePi"
 VERSION = (0, 1, 0)
 NAME = "Discord Relay"
@@ -8,17 +18,25 @@ and broadcasts messages from the Discord server to the Minecraft server
 
 DISABLED = False
 
-import discord
 
+# noinspection PyAttributeOutsideInit,PyPep8Naming
+# noinspection PyUnusedLocal,PyUnresolvedReferences,PyCompatibility
 class Main:
     def __init__(self, api, log):
         self.api = api
         self.log = log
 
     def onEnable(self):
+        if not discord or not PY3:
+            self.log.warning(
+                "Discord Relay plugin requires Python 3 and the discord import."
+            )
+            return False
         self.client = discord.Client()
         self.server = discord.Server(id="serverID")
-        self.sendChannel = discord.Channel(name="channelName", server=self.server, id="channelID")
+        self.sendChannel = discord.Channel(
+            name="channelName", server=self.server, id="channelID"
+        )
 
         self.api.registerEvent("player.message", self.player_message)
         self.api.registerEvent("player.login", self.login)
@@ -27,10 +45,12 @@ class Main:
         self.player_data = self.discord_storage.Data
 
         self.api.registerCommand("disctoggle", self._toggle, None)
-        self.api.registerHelp("DiscordRelay", "sends and receives messages from Discord",
-                              [("/disctoggle",
-                                "toggles whether you want to communicate with the Discord server",
-                                None)])
+        self.api.registerHelp(
+            "DiscordRelay", "sends and receives messages from Discord",
+            [("/disctoggle",
+              "toggles whether you want to communicate with the Discord server",
+              None)]
+        )
 
         @self.client.event
         async def on_message(message):


### PR DESCRIPTION
Plugin only functions under python 3.5 or later. Many wrapper users are using
2.7 or 3.4.
Since discord is a non-standard import and is not part of the Wrapper.py
packaging requirements, this also needs to be checked for during onEnable.